### PR TITLE
Small fix for executor example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ from dask.distributed import Executor
 from dask import delayed
 
 client = Executor("104.196.185.187:8786")
-tasks = [dask.delayed(sqrt)(i) for i in range(100)]
+tasks = [delayed(sqrt)(i) for i in range(100)]
 results = client.compute(tasks, sync=True)
 print(results)
 ```


### PR DESCRIPTION
In the README example, there was a problem with using `dask.delayed` since `delayed` is imported from `dask`:

```python
from math import sqrt
from dask.distributed import Executor
from dask import delayed
# no import of `dask`
...
tasks = [dask.delayed(sqrt)(i) for i in range(100)] 
# `dask` is not declared

tasks = [delayed(sqrt)(i) for i in range(100)]
# works
...
```
I know that's just a little picky note, but I hope it maybe helps :v:

